### PR TITLE
Adding `dnsSearch` networking option

### DIFF
--- a/kind/schema_kind_config.go
+++ b/kind/schema_kind_config.go
@@ -145,6 +145,11 @@ func kindConfigNetworkingFields() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Optional: true,
 		},
+		"dns_search": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
 	}
 	return s
 }

--- a/kind/structure_kind_config.go
+++ b/kind/structure_kind_config.go
@@ -145,6 +145,16 @@ func flattenKindConfigNetworking(d map[string]interface{}) v1alpha4.Networking {
 		obj.ServiceSubnet = serviceSubnet.(string)
 	}
 
+	dnsSearch := mapKeyIfExists(d, "dns_search")
+	if dnsSearch != nil {
+		vals := []string{}
+		for _, k := range dnsSearch.([]interface{}) {
+			data := k.(string)
+			vals = append(vals, data)
+		}
+		obj.DNSSearch = &vals
+	}
+
 	return obj
 }
 


### PR DESCRIPTION
Latest kind release adds a new networking configuration for docker setup: 
https://github.com/kubernetes-sigs/kind/releases/tag/v0.18.0
https://github.com/kubernetes-sigs/kind/pull/3098

This PR is enabling the option via configuration.