### PR TITLE
add a test and add mapping for kube_proxy_mode assignement

### DIFF
--- a/kind/resource_cluster_test.go
+++ b/kind/resource_cluster_test.go
@@ -182,6 +182,20 @@ func TestAccClusterConfigBase(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccClusterConfigAndExtraWithNetworkValuesKubeProxyDisabled(clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterCreate(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
+					resource.TestCheckNoResourceAttr(resourceName, "node_image"),
+					resource.TestCheckResourceAttr(resourceName, "wait_for_ready", "false"),
+					resource.TestCheckResourceAttr(resourceName, "kind_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "kind_config.0.kind", "Cluster"),
+					resource.TestCheckResourceAttr(resourceName, "kind_config.0.api_version", "kind.x-k8s.io/v1alpha4"),
+					resource.TestCheckResourceAttr(resourceName, "kind_config.0.networking.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "kind_config.0.networking.0.kube_proxy_mode", "none"),
+				),
+			},
+			{
 				Config: testAccClusterConfigAndRuntimeConfig(clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterCreate(resourceName),
@@ -749,6 +763,23 @@ resource "kind_cluster" "test" {
 	networking {
 		api_server_address = "127.0.0.1"
 		api_server_port = 6443
+	}
+  }
+}
+`, name)
+}
+
+func testAccClusterConfigAndExtraWithNetworkValuesKubeProxyDisabled(name string) string {
+	return fmt.Sprintf(`
+resource "kind_cluster" "test" {
+  name = "%s"
+  wait_for_ready = false
+  kind_config {
+	kind = "Cluster"
+	api_version = "kind.x-k8s.io/v1alpha4"
+
+	networking {
+		kube_proxy_mode = "none"
 	}
   }
 }

--- a/kind/structure_kind_config.go
+++ b/kind/structure_kind_config.go
@@ -157,7 +157,10 @@ func flattenKindConfigNetworking(d map[string]interface{}) v1alpha4.Networking {
 			obj.KubeProxyMode = v1alpha4.IPTablesProxyMode
 		case string(v1alpha4.IPVSProxyMode):
 			obj.KubeProxyMode = v1alpha4.IPVSProxyMode
+		case "none":
+			obj.KubeProxyMode = "none"
 		}
+
 	}
 
 	podSubnet := mapKeyIfExists(d, "pod_subnet")


### PR DESCRIPTION
Looks like https://github.com/tehcyx/terraform-provider-kind/issues/46 uncovered, that `kube_proxy_mode = "none"` does not map correctly.