### PR TITLE
Add support for IP DualStackFamily

### DIFF
--- a/kind/structure_kind_config.go
+++ b/kind/structure_kind_config.go
@@ -147,6 +147,8 @@ func flattenKindConfigNetworking(d map[string]interface{}) v1alpha4.Networking {
 			obj.IPFamily = v1alpha4.IPv4Family
 		case string(v1alpha4.IPv6Family):
 			obj.IPFamily = v1alpha4.IPv6Family
+		case string(v1alpha4.DualStackFamily):
+			obj.IPFamily = v1alpha4.DualStackFamily
 		}
 	}
 


### PR DESCRIPTION
Adds support for `dual` as the `ip_family` setting.

Dual stack clusters are supported in Kind 0.11+ and on Kubernetes 1.20+ (see https://kind.sigs.k8s.io/docs/user/configuration/#dual-stack-clusters)

Resolves #69 