### PR TITLE
ci: fix acc tests failing on expired HashiCorp PGP key

### DIFF
--- a/.github/workflows/labeled-pr-testing.yml
+++ b/.github/workflows/labeled-pr-testing.yml
@@ -19,6 +19,9 @@ jobs:
     - uses: actions/setup-go@v6
       with:
         go-version-file: go.mod
-    
+    - uses: hashicorp/setup-terraform@v3
+      with:
+        terraform_wrapper: false
+
     - name: Run tests
       run: make testacc


### PR DESCRIPTION
## Problem

All PR test runs fail before any test executes:

```
cannot run Terraform provider tests: failed to find or install Terraform CLI:
unable to verify checksums signature: openpgp: key expired
```

Acc tests run `TF_ACC=1 go test ./kind`. The plugin SDK auto-downloads the Terraform CLI via `hc-install` when none is on PATH, then verifies the release signature against a bundled HashiCorp PGP key that has expired. Verification fails → no binary → the `kind` package FAILs. Not code-related; it hits every open PR (e.g. #107, #109, #110).

## Fix

Add `hashicorp/setup-terraform@v3` to the test workflow so Terraform is on PATH. The SDK's PATH lookup finds it and skips the signed download entirely. `terraform_wrapper: false` keeps terraform-exec output clean.

## Rollback

Revert this commit; no state or infra touched.